### PR TITLE
fix language code verification

### DIFF
--- a/koboanki/config.json
+++ b/koboanki/config.json
@@ -3,7 +3,7 @@
     "dl_threads": 50,
     "dl_timeout": 2,
     "language_list": [
-        "en_GB",
-        "en_US"
+        "en-uk",
+        "en"
     ]
 }

--- a/koboanki/config.md
+++ b/koboanki/config.md
@@ -1,17 +1,20 @@
 The following languages are available ([source](https://dictionaryapi.dev/)):
 
-- `en_US`: English (US)
-- `hi`: Hindi
+- `ar`: Arabic
+- `cs`: Czech
+- `de`: German
+- `en`: English (US)
+- `en-uk`: English (UK)
 - `es`: Spanish
 - `fr`: French
-- `ja`: Japanese
-- `ru`: Russian
-- `en_GB`: English (UK)
-- `de`: German
+- `hi`: Hindi
 - `it`: Italian
+- `ja`: Japanese
 - `ko`: Korean
-- `p-Br`: Brazilian Portuguese
-- `ar`: Arabic
+- `nl`: Dutch
+- `pt-BR`: Brazilian Portuguese
+- `ru`: Russian
+- `sk`: Slovak
 - `tr`: Turkish
 
 The order of the dictionary language codes corresponds to the order in which those dictionaries are looked up from for a given word. That is to say, priority is given to the leftmost dictionary.

--- a/koboanki/meta.json
+++ b/koboanki/meta.json
@@ -1,1 +1,1 @@
-{config:{"languageList": ["en_GB", "en_US"]}}
+{"config": {"dl_retries": 3, "dl_threads": 50, "dl_timeout": 2, "language_list": ["en-uk", "en"]}}

--- a/koboanki/utils.py
+++ b/koboanki/utils.py
@@ -102,6 +102,25 @@ def add_to_collection(word_defs: dict, deck_id: int) -> None:
 ### Verification
 # TODO
 
+# See https://github.com/meetDeveloper/freeDictionaryAPI/blob/master/modules/utils.js
+SUPPORTED_LANGUAGES = (
+        'hi', 	 # Hindi
+        'en',    # English (US)
+        'en-uk', # English (UK)
+        'es', 	 # Spanish
+        'fr',	 # French
+        'ja',    # Japanese
+        'cs',    # Czech
+        'nl',    # Dutch
+        'sk',    # Slovak
+        'ru',	 # Russian
+        'de', 	 # German
+        'it', 	 # Italian
+        'ko',	 # Korean
+        'pt-BR', # Brazilian Portuguese
+        'ar',    # Arabic
+        'tr'     # Turkish
+)
 
 def verify_config(config: dict) -> bool:
     if not config:
@@ -114,9 +133,7 @@ def verify_config(config: dict) -> bool:
         showInfo("Language list is empty")
         return False
 
-    links = {code: get_link(code, "test") for code in config["language_list"]}
-    links_statuses = {code: try_link(link) for code, link in links.items()}
-    failed_codes = [code for code, status in links_statuses.items() if not status]
+    failed_codes = [code for code in config["language_list"] if code not in SUPPORTED_LANGUAGES]
     if failed_codes:
         showInfo(f"The following language codes are not valid: {failed_codes}")
         return False
@@ -148,7 +165,7 @@ def get_words(config):
         return
 
     # check internet connection
-    if not try_link(get_link("en_US", "test")):
+    if not try_link(get_link("en", "test")):
         showInfo("Can't access server, faulty internet connection?")
         return
 


### PR DESCRIPTION
See the Dictionary API for supported language codes.
https://github.com/meetDeveloper/freeDictionaryAPI/blob/master/modules/utils.js

Verification was broken for languages that do not have the word "test", as the API returns 404 when the word is not found. better to just check against a list of language codes.